### PR TITLE
Make `Spline` rely on `VecDeque` instead of `Vec`

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -26,7 +26,7 @@ impl<'a, T, V> Iterator for Iter<'a, T, V> {
   fn next(&mut self) -> Option<Self::Item> {
     let r = self.spline.0.get(self.i);
 
-    if let Some(_) = r {
+    if r.is_some() {
       self.i += 1;
     }
 

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -258,8 +258,17 @@ impl<T, V> Spline<T, V> {
   where
     T: PartialOrd,
   {
+    let is_sort_required = if let Some(old_max) = self.0.back() {
+      old_max.t > key.t
+    } else {
+      false
+    };
+
     self.0.push_back(key);
-    self.internal_sort();
+
+    if is_sort_required {
+      self.internal_sort();
+    }
   }
 
   /// Remove a key from the spline.

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -118,7 +118,7 @@ impl<T, V> Spline<T, V> {
     T: Interpolator,
     V: Interpolate<T>,
   {
-    let keys = self.0.as_slices().0;
+    let keys = self.keys();
     let i = search_lower_cp(keys, &t)?;
     let cp0 = &keys[i];
 
@@ -264,11 +264,7 @@ impl<T, V> Spline<T, V> {
 
   /// Remove a key from the spline.
   pub fn remove(&mut self, index: usize) -> Option<Key<T, V>> {
-    if index >= self.0.len() {
-      None
-    } else {
-      Some(self.0.remove(index).unwrap())
-    }
+    self.0.remove(index)
   }
 
   /// Update a key and return the key already present.

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -50,11 +50,12 @@ impl<T, V> Spline<T, V> {
 
   /// Create a new spline out of keys. The keys don’t have to be sorted even though it’s recommended
   /// to provide ascending sorted ones (for performance purposes).
-  pub fn from_vec(keys: Vec<Key<T, V>>) -> Self
+  pub fn from_vec<K>(keys: K) -> Self
   where
+    K: Into<VecDeque<Key<T, V>>>,
     T: PartialOrd,
   {
-    let mut spline = Spline(VecDeque::from(keys));
+    let mut spline = Spline(keys.into());
     spline.internal_sort();
     spline
   }
@@ -78,7 +79,7 @@ impl<T, V> Spline<T, V> {
     I: Iterator<Item = Key<T, V>>,
     T: PartialOrd,
   {
-    Self::from_vec(iter.collect())
+    Self::from_vec(iter.collect::<VecDeque<Key<T, V>>>())
   }
 
   /// Retrieve the keys of a spline.

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -63,7 +63,7 @@ impl<T, V> Spline<T, V> {
   /// new keys should be faster than creating a new [`Spline`]
   #[inline]
   pub fn clear(&mut self) {
-    self.0.clear()
+    self.0.clear();
   }
 
   /// Create a new spline by consuming an `Iterater<Item = Key<T>>`. They keys don’t have to be
@@ -119,7 +119,7 @@ impl<T, V> Spline<T, V> {
     V: Interpolate<T>,
   {
     let keys = self.0.as_slices().0;
-    let i = search_lower_cp(keys, t)?;
+    let i = search_lower_cp(keys, &t)?;
     let cp0 = &keys[i];
 
     let value = match cp0.interpolation {
@@ -220,7 +220,7 @@ impl<T, V> Spline<T, V> {
     }
 
     self.sample_with_key(t).or_else(move || {
-      let first = self.0.get(0).unwrap();
+      let first = self.0.front().unwrap();
 
       if t <= first.t {
         let sampled = SampledWithKey {
@@ -229,7 +229,7 @@ impl<T, V> Spline<T, V> {
         };
         Some(sampled)
       } else {
-        let last = self.0.get(self.len() - 1).unwrap();
+        let last = self.0.back().unwrap();
 
         if t >= last.t {
           let sampled = SampledWithKey {
@@ -329,7 +329,7 @@ pub struct KeyMut<'a, T, V> {
 
 // Find the lower control point corresponding to a given time.
 // It has the property to have a timestamp smaller or equal to t
-fn search_lower_cp<T, V>(cps: &[Key<T, V>], t: T) -> Option<usize>
+fn search_lower_cp<T, V>(cps: &[Key<T, V>], t: &T) -> Option<usize>
 where
   T: PartialOrd,
 {
@@ -337,9 +337,9 @@ where
   if len < 2 {
     return None;
   }
-  match cps.binary_search_by(|key| key.t.partial_cmp(&t).unwrap()) {
+  match cps.binary_search_by(|key| key.t.partial_cmp(t).unwrap()) {
     Err(i) if i >= len => None,
-    Err(i) if i == 0 => None,
+    Err(0) => None,
     Err(i) => Some(i - 1),
     Ok(i) if i == len - 1 => None,
     Ok(i) => Some(i),


### PR DESCRIPTION
This PR makes the collection of `Key`s of `Spline` a `VecDeque`.

### Motivation

It's common to manipulate `Spline` objects  removing elements from the head of the collection; this is the case for example of live charts, in which often elements are removed from the head as time passes.
Using `Vec` makes this kind of operation have a complexity of O(n) because all the elements following the first one are shifted one place to the left.
Instead, calling `.remove()` on a `VecDeque` automatically shifts the least amount of elements possible (being it a circular buffer, the part of the queue closer to the removal point will be subject of the shift). 

***

Before merging I suggest anyway to run this feature against a benchmark if possible, and to have a look at the comments I left on the PR code.

Fixes #105 

***

### Bonus

I've also added a check to only call `internal_sort()` when `add`ing a key that's lower than the last already present key; in this way we never sort the collection in case the keys are being `add`ed in order (as it's common to do).

_Note that the algorithm used by `sort_by` is inspired by [timsort](https://en.wikipedia.org/wiki/Timsort) that still has a O(n) complexity if all the elements are already sorted._