### PR TITLE
Fix `Spline` update operations based on `VecDequeue`

### DIFF
--- a/src/spline.rs
+++ b/src/spline.rs
@@ -84,7 +84,6 @@ impl<T, V> Spline<T, V> {
 
   /// Retrieve the keys of a spline.
   pub fn keys(&self) -> &[Key<T, V>] {
-    println!("Slices len: {} / {}", self.0.as_slices().0.len(), self.0.as_slices().1.len());
     self.0.as_slices().0
   }
 

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -267,6 +267,7 @@ impl<T, V> Spline<T, V> {
     };
 
     self.0.push_back(key);
+    self.0.make_contiguous();
 
     if is_sort_required {
       self.internal_sort();

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -275,7 +275,9 @@ impl<T, V> Spline<T, V> {
 
   /// Remove a key from the spline.
   pub fn remove(&mut self, index: usize) -> Option<Key<T, V>> {
-    self.0.remove(index)
+    let removed = self.0.remove(index);
+    self.0.make_contiguous();
+    removed
   }
 
   /// Update a key and return the key already present.

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -84,6 +84,7 @@ impl<T, V> Spline<T, V> {
 
   /// Retrieve the keys of a spline.
   pub fn keys(&self) -> &[Key<T, V>] {
+    println!("Slices len: {} / {}", self.0.as_slices().0.len(), self.0.as_slices().1.len());
     self.0.as_slices().0
   }
 


### PR DESCRIPTION
We are returning keys with `self.0.as_slices().0` but I've sadly found out that this is a problem if `remove` was previously called, as this operation can make some elements go in the second slice (the `.1` field of the tuple returned by `as_slices()`).

This is fixed by calling `make_contiguous` after each update operation to the spline object, ensuring all the elements will be in the first slice.

Tests about `Spline` updated with both `remove` and `add` should be added, and this should be benchmarked to see if the performance is actually better against normal `Vec`.

This bug was introduced in #106.