### PR TITLE
Update nalgebra maximum version to 0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ std = []
 [dependencies]
 cgmath = { version = ">=0.17, <0.19", optional = true }
 glam = { version = ">=0.10, <0.27", optional = true }
-nalgebra = { version = ">=0.21, <0.33", optional = true }
+nalgebra = { version = ">=0.21, <0.34", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ std = []
 cgmath = { version = ">=0.17, <0.19", optional = true }
 glam = { version = ">=0.10, <0.27", optional = true }
 nalgebra = { version = ">=0.21, <0.33", optional = true }
-serde =  { version = "1", features = ["derive"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 float-cmp = ">=0.6, < 0.10"


### PR DESCRIPTION
Just a bump on the maximum version of nalgebra. I tested it by manually forcing 0.33 briefly just to check that it still works. Your test at the very least passes with it.