### PR TITLE
fix: f64 glam interpolation support

### DIFF
--- a/src/glam.rs
+++ b/src/glam.rs
@@ -1,8 +1,13 @@
 use crate::impl_Interpolate;
-use glam::{Quat, Vec2, Vec3, Vec3A, Vec4};
+use glam::{DQuat, DVec2, DVec3, DVec4, Quat, Vec2, Vec3, Vec3A, Vec4};
 
 impl_Interpolate!(f32, Vec2, std::f32::consts::PI);
 impl_Interpolate!(f32, Vec3, std::f32::consts::PI);
 impl_Interpolate!(f32, Vec3A, std::f32::consts::PI);
 impl_Interpolate!(f32, Vec4, std::f32::consts::PI);
 impl_Interpolate!(f32, Quat, std::f32::consts::PI);
+
+impl_Interpolate!(f64, DVec2, std::f64::consts::PI);
+impl_Interpolate!(f64, DVec3, std::f64::consts::PI);
+impl_Interpolate!(f64, DVec4, std::f64::consts::PI);
+impl_Interpolate!(f64, DQuat, std::f64::consts::PI);


### PR DESCRIPTION
Hi there!
While working on an experimental library at work, I found out that, while working with 64-bit arrays provided by glam, their Interpolate implementation was missing.

Hope this could help, and if necessary, I could fix other parts to be aligned with project coding standard or if there is something missing (e.g. I think that all available 64bit implementations have been imported, but not completely sure).

Thanks!